### PR TITLE
Fixed Typo in Code Snippet in Chapter 3.4 

### DIFF
--- a/course/c03_advanced_data_types/chapter 3.4 set.md
+++ b/course/c03_advanced_data_types/chapter 3.4 set.md
@@ -188,7 +188,7 @@ We can not access individual item of the set, however we can iterate through all
 prime = {2, 3, 5, 7, 11, 13, 17}
 
 for item in prime:
-    print(prime)
+    print(item)
 ```
 
 ## Some useful Set Methods


### PR DESCRIPTION
In this pull request, I have corrected a typo in a code snippet located in the file `course/c03_advanced_data_types/chapter 3.4 set.md`. 

The original code snippet was:

```python
prime = {2, 3, 5, 7, 11, 13, 17}
for item in prime:
    print(prime)

In the original code, the print statement was printing the entire prime set in every iteration of the loop, which I believe was a mistake. The intention was likely to print each individual item in the prime set.

I have corrected this to:

prime = {2, 3, 5, 7, 11, 13, 17}
for item in prime:
    print(item)

With this change, the print statement now correctly prints each individual item in the prime set.

This correction will help avoid confusion for readers who are learning about sets and loops in Python. Please review these changes and let me know if any further modifications are required. I'm open to feedback. Thank you for considering my pull request.

